### PR TITLE
Fix version numbers for stable builds

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,12 +152,12 @@
           $('.option-set').on('click', '.btn', selectOption);
           updateCommand();
       }(jQuery, {
-          'stable,conda,no': 'conda install -c conda-forge rdkit deepchem==2.5.0<br/>pip install tensorflow~=2.4',
-          'stable,conda,yes': 'conda install -c conda-forge rdkit deepchem==2.5.0<br/>pip install tensorflow-gpu~=2.4',
+          'stable,conda,no': 'conda install -c conda-forge rdkit deepchem==2.6.1<br/>pip install tensorflow~=2.4',
+          'stable,conda,yes': 'conda install -c conda-forge rdkit deepchem==2.6.1<br/>pip install tensorflow-gpu~=2.4',
           'stable,pip,no': 'pip install tensorflow~=2.4<br/>pip install deepchem',
           'stable,pip,yes': 'pip install tensorflow-gpu~=2.4<br/>pip install deepchem',
-          'stable,docker,no': 'docker pull deepchemio/deepchem:2.5.0<br/>docker run -it deepchemio/deepchem:2.5.0',
-          'stable,docker,yes': 'docker pull deepchemio/deepchem:2.5.0<br/>docker run --gpus all deepchemio/deepchem:2.5.0',
+          'stable,docker,no': 'docker pull deepchemio/deepchem:2.6.1<br/>docker run -it deepchemio/deepchem:2.6.1',
+          'stable,docker,yes': 'docker pull deepchemio/deepchem:2.6.1<br/>docker run --gpus all deepchemio/deepchem:2.6.1',
           'nightly,conda,no': 'We do not support the nightly version via conda',
           'nightly,conda,yes': 'We do not support the nightly version via conda',
           'nightly,pip,no': 'pip install --pre deepchem<br/>pip install tensorflow~=2.4',


### PR DESCRIPTION
This PR will update the version numbers to the latest stable builds of deepchem. This should help users avoid falling into the trap of using an outdated and less powerful version.