### PR TITLE
Updating repository dispatch event in build_pdf_book workflow

### DIFF
--- a/.github/workflows/build_pdf_book.yml
+++ b/.github/workflows/build_pdf_book.yml
@@ -3,7 +3,7 @@ name: Build latest version of PDF Book
 on:
   workflow_dispatch:
   repository_dispatch:
-    types: [rebuild-book]
+    types: [ rebuild-website ]
 
 permissions:
   contents: write


### PR DESCRIPTION
### Title: Updated repository dispatch event in build_pdf_book workflow.

### Changes Made:
- Updated the repository dispatch event to 'rebuild-website' so that both the website and the book rebuilds simultaneously whenever new commits are pushed on the `master` branch of `deepchem` repository.