### PR TITLE
Fixed 'Loading MathAjax' at the end of each tutorial in book

### DIFF
--- a/new-website/utils/tutorials/build_pdf_book.py
+++ b/new-website/utils/tutorials/build_pdf_book.py
@@ -81,7 +81,7 @@ def html_to_pdf(data_path=DATA_PATH, info_path=INFO_PATH, pdf_path=PDF_PATH):
             signal.alarm(60)
             try:
                 print(i, j)
-                pdfkit.from_file(data_path + j.strip()[:-5] + "html", pdf_path + j.strip()[:-5] + "pdf")
+                pdfkit.from_file(data_path + j.strip()[:-5] + "html", pdf_path + j.strip()[:-5] + "pdf", options={'javascript-delay':'5000'})
                 print("Conversion Successful")
             except Exception as e:
                 print("Exception occured: {}".format(e))   


### PR DESCRIPTION
### Title: Fixed 'Loading MathAjax' at the end of each tutorial.

### Changes Made:
- Updated html_to_pdf method in build_pdf_book script by adding a javascript delay of 5s, so that the javascript is loaded before the webpage is converted to pdf.