### PR TITLE
Fix: Update outdated Gitter link with Discord link in footer (#48)

### DIFF
--- a/new-website/deepchem/components/Footer/Footer.js
+++ b/new-website/deepchem/components/Footer/Footer.js
@@ -44,7 +44,7 @@ function Footer() {
             <Link href="https://forum.deepchem.io/" target={"_blank"}>
               Forums
             </Link>
-            <Link href="https://gitter.im/deepchem/Lobby" target={"_blank"}>
+            <Link href="https://discord.gg/deXJEfyn5x" target={"_blank"}>
               Discuss
             </Link>
           </div>


### PR DESCRIPTION
**Description:**
This PR fixes #48 by replacing the outdated Gitter link in the website footer with the official DeepChem Discord invite link.

**Changes made:**
- Removed Gitter link from the footer.
- Added the official DeepChem Discord invite link in its place.

**Reason for change:**
The Gitter channel is no longer active, and the DeepChem community now uses Discord for discussions and support. Updating the footer ensures visitors can connect to the correct and active community channel.